### PR TITLE
Use OpenVINO model engine for BertEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
@@ -19,11 +19,13 @@ package com.johnsnowlabs.ml.ai
 import ai.onnxruntime.OnnxTensor
 import com.johnsnowlabs.ml.ai.util.PrepareEmbeddings
 import com.johnsnowlabs.ml.onnx.OnnxWrapper
+import com.johnsnowlabs.ml.openvino.OpenvinoWrapper
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.ml.tensorflow.{TensorResources, TensorflowWrapper}
-import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+import org.intel.openvino.Tensor
 
 import scala.collection.JavaConverters._
 
@@ -39,6 +41,8 @@ import scala.collection.JavaConverters._
   *   Bert Model wrapper with TensorFlow Wrapper
   * @param onnxWrapper
   *   Bert Model wrapper with ONNX Wrapper
+  * @param openvinoWrapper
+  *   Bert Model wrapper with OpenVINO Wrapper
   * @param sentenceStartTokenId
   *   Id of sentence start Token
   * @param sentenceEndTokenId
@@ -53,6 +57,7 @@ import scala.collection.JavaConverters._
 private[johnsnowlabs] class Bert(
     val tensorflowWrapper: Option[TensorflowWrapper],
     val onnxWrapper: Option[OnnxWrapper],
+    val openvinoWrapper: Option[OpenvinoWrapper],
     sentenceStartTokenId: Int,
     sentenceEndTokenId: Int,
     configProtoBytes: Option[Array[Byte]] = None,
@@ -65,6 +70,7 @@ private[johnsnowlabs] class Bert(
   val detectedEngine: String =
     if (tensorflowWrapper.isDefined) TensorFlow.name
     else if (onnxWrapper.isDefined) ONNX.name
+    else if (openvinoWrapper.isDefined) Openvino.name
     else TensorFlow.name
 
   private def sessionWarmup(): Unit = {
@@ -127,6 +133,39 @@ private[johnsnowlabs] class Bert(
             embeddings
           } finally if (results != null) results.close()
         }
+      case Openvino.name =>
+        val shape = Array(batchLength, maxSentenceLength)
+        val tokenTensors = new Tensor(shape, batch.flatMap(_.toSeq).toArray)
+        val segmentTensors = new Tensor(shape, Array.fill(batchLength * maxSentenceLength)(0))
+        val maskTensors = new Tensor(
+          shape,
+          batch.flatMap(sentence => sentence.map(x => if (x == 0) 0 else 1)).toArray)
+
+        val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
+        inferRequest.set_tensor(
+          _tfBertSignatures.getOrElse(
+            ModelSignatureConstants.InputIdsV1.key,
+            "missing_input_id_key"),
+          tokenTensors)
+        inferRequest.set_tensor(
+          _tfBertSignatures
+            .getOrElse(ModelSignatureConstants.AttentionMaskV1.key, "missing_input_mask_key"),
+          maskTensors)
+        inferRequest.set_tensor(
+          _tfBertSignatures
+            .getOrElse(ModelSignatureConstants.TokenTypeIdsV1.key, "missing_segment_ids_key"),
+          segmentTensors)
+
+        inferRequest.infer()
+
+        val result = inferRequest.get_tensor(
+          _tfBertSignatures
+            .getOrElse(
+              ModelSignatureConstants.LastHiddenStateV1.key,
+              "missing_sequence_output_key"))
+        val embeddings = result.data()
+
+        embeddings
       case _ =>
         val tensors = new TensorResources()
 
@@ -229,6 +268,36 @@ private[johnsnowlabs] class Bert(
             embeddings
           } finally if (results != null) results.close()
         }
+      case Openvino.name =>
+        val shape = Array(batchLength, maxSentenceLength)
+        val tokenTensors = new Tensor(shape, batch.flatMap(_.toSeq).toArray)
+        val segmentTensors = new Tensor(shape, Array.fill(batchLength * maxSentenceLength)(0))
+        val maskTensors = new Tensor(
+          shape,
+          batch.flatMap(sentence => sentence.map(x => if (x == 0) 0 else 1)).toArray)
+
+        val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request
+        inferRequest.set_tensor(
+          _tfBertSignatures.getOrElse(
+            ModelSignatureConstants.InputIdsV1.key,
+            "missing_input_id_key"),
+          tokenTensors)
+        inferRequest.set_tensor(
+          _tfBertSignatures
+            .getOrElse(ModelSignatureConstants.AttentionMaskV1.key, "missing_input_mask_key"),
+          maskTensors)
+        inferRequest.set_tensor(
+          _tfBertSignatures
+            .getOrElse(ModelSignatureConstants.TokenTypeIdsV1.key, "missing_segment_ids_key"),
+          segmentTensors)
+
+        inferRequest.infer()
+
+        val result = inferRequest.get_tensor(
+          _tfBertSignatures
+            .getOrElse(ModelSignatureConstants.PoolerOutput.key, "missing_pooled_output_key"))
+        val embeddings = result.data()
+        embeddings
       case _ =>
         val tensors = new TensorResources()
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
@@ -30,8 +30,12 @@ import scala.collection.JavaConverters._
 
 /** TensorFlow backend for '''RoBERTa''' and '''Longformer'''
   *
-  * @param tensorflowWrapper
-  *   tensorflowWrapper class
+ * @param tensorflowWrapper
+ *   Model wrapper with TensorFlow Wrapper
+ * @param onnxWrapper
+ *   Model wrapper with ONNX Wrapper
+ * @param openvinoWrapper
+ *   Model wrapper with OpenVINO Wrapper
   * @param sentenceStartTokenId
   *   special token id for `<s>`
   * @param sentenceEndTokenId

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
@@ -59,6 +59,7 @@ private[johnsnowlabs] class RoBerta(
   val detectedEngine: String =
     if (tensorflowWrapper.isDefined) TensorFlow.name
     else if (onnxWrapper.isDefined) ONNX.name
+    else if (openvinoWrapper.isDefined) Openvino.name
     else TensorFlow.name
 
   private def sessionWarmup(): Unit = {
@@ -112,10 +113,10 @@ private[johnsnowlabs] class RoBerta(
         }
       case Openvino.name =>
         val shape = Array(batchLength, maxSentenceLength)
-        val tokenTensors = new Tensor(shape, batch.flatMap(_.toSeq).toArray)
+        val tokenTensors = new Tensor(shape, batch.flatMap(x => x.map(x => x.toLong)).toArray)
         val maskTensors = new Tensor(
           shape,
-          batch.flatMap(sentence => sentence.map(x => if (x == padTokenId) 0 else 1)).toArray)
+          batch.flatMap(sentence => sentence.map(x => if (x == padTokenId) 0L else 1L)).toArray)
 
         val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
         inferRequest.set_tensor(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
@@ -19,11 +19,13 @@ package com.johnsnowlabs.ml.ai
 import ai.onnxruntime.OnnxTensor
 import com.johnsnowlabs.ml.ai.util.PrepareEmbeddings
 import com.johnsnowlabs.ml.onnx.OnnxWrapper
+import com.johnsnowlabs.ml.openvino.OpenvinoWrapper
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.ml.tensorflow.{TensorResources, TensorflowWrapper}
-import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+import org.intel.openvino.Tensor
 
 import scala.collection.JavaConverters._
 
@@ -43,6 +45,7 @@ import scala.collection.JavaConverters._
 private[johnsnowlabs] class RoBerta(
     val tensorflowWrapper: Option[TensorflowWrapper],
     val onnxWrapper: Option[OnnxWrapper],
+    val openvinoWrapper: Option[OpenvinoWrapper],
     sentenceStartTokenId: Int,
     sentenceEndTokenId: Int,
     padTokenId: Int,
@@ -107,6 +110,31 @@ private[johnsnowlabs] class RoBerta(
 
           } finally if (results != null) results.close()
         }
+      case Openvino.name =>
+        val shape = Array(batchLength, maxSentenceLength)
+        val tokenTensors = new Tensor(shape, batch.flatMap(_.toSeq).toArray)
+        val maskTensors = new Tensor(
+          shape,
+          batch.flatMap(sentence => sentence.map(x => if (x == padTokenId) 0 else 1)).toArray)
+
+        val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
+        inferRequest.set_tensor(
+          _tfRoBertaSignatures.getOrElse(
+            ModelSignatureConstants.InputIds.key,
+            "missing_input_id_key"),
+          tokenTensors)
+        inferRequest.set_tensor(
+          _tfRoBertaSignatures
+            .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
+          maskTensors)
+
+        inferRequest.infer()
+
+        val result = inferRequest.get_tensor(_tfRoBertaSignatures
+          .getOrElse(ModelSignatureConstants.LastHiddenState.key, "missing_sequence_output_key"))
+        val embeddings = result.data()
+
+        embeddings
       case _ =>
         val tensors = new TensorResources()
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
@@ -26,7 +26,6 @@ import com.johnsnowlabs.ml.tensorflow.{TensorResources, TensorflowWrapper}
 import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
-import org.intel.openvino.Tensor
 
 import scala.collection.JavaConverters._
 
@@ -65,6 +64,10 @@ import scala.collection.JavaConverters._
   *
   * @param tensorflowWrapper
   *   XlmRoberta Model wrapper with TensorFlowWrapper
+ * @param onnxWrapper
+ *   XlmRoberta Model wrapper with ONNX Wrapper
+ * @param openvinoWrapper
+ *   XlmRoberta Model wrapper with OpenVINO Wrapper
   * @param spp
   *   XlmRoberta SentencePiece model with SentencePieceWrapper
   * @param caseSensitive

--- a/src/main/scala/com/johnsnowlabs/ml/ai/util/PrepareEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/util/PrepareEmbeddings.scala
@@ -90,7 +90,7 @@ private[johnsnowlabs] object PrepareEmbeddings {
     val maskTensors = new org.intel.openvino.Tensor(
       shape,
       batch
-        .flatMap(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+        .flatMap(sentence => sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
         .toArray)
     val segmentTensors =
       new org.intel.openvino.Tensor(shape, Array.fill(batchLength * maxSentenceLength)(0))

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoSerializeModel.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.ml.openvino
 
 import com.johnsnowlabs.util.FileHelper

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoSerializeModel.scala
@@ -1,0 +1,60 @@
+package com.johnsnowlabs.ml.openvino
+
+import com.johnsnowlabs.util.FileHelper
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+import java.util.UUID
+
+trait WriteOpenvinoModel {
+
+  def writeOpenvinoModel(
+      path: String,
+      spark: SparkSession,
+      openvinoWrapper: OpenvinoWrapper,
+      suffix: String,
+      fileName: String): Unit = {
+    val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
+    val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
+
+    val tmpFolder = Files
+      .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + suffix)
+      .toAbsolutePath
+      .toString
+
+    val savedOvModel = Paths.get(tmpFolder, fileName).toString
+    openvinoWrapper.saveToFile(savedOvModel)
+
+    fs.copyFromLocalFile(new Path(savedOvModel), new Path(path))
+    FileUtils.deleteDirectory(new File(tmpFolder))
+  }
+}
+
+trait ReadOpenvinoModel {
+  val openvinoFile: String
+
+  def readOpenvinoModel(
+      path: String,
+      spark: SparkSession,
+      suffix: String,
+      zipped: Boolean = true): OpenvinoWrapper = {
+
+    val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
+    val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
+
+    val tmpFolder = Files
+      .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + suffix)
+      .toAbsolutePath
+      .toString
+
+    fs.copyToLocalFile(new Path(path, openvinoFile), new Path(tmpFolder))
+    val localPath = new Path(tmpFolder, openvinoFile).toString
+    val (openvinoWrapper, _) = OpenvinoWrapper.fromOpenvinoFormat(localPath, zipped = zipped)
+
+    FileHelper.delete(tmpFolder)
+    openvinoWrapper
+  }
+}

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -1,0 +1,199 @@
+package com.johnsnowlabs.ml.openvino
+
+import com.johnsnowlabs.ml.tensorflow.TensorflowWrapper
+import com.johnsnowlabs.ml.tensorflow.io.ChunkBytes
+import com.johnsnowlabs.ml.tensorflow.sign.ModelSignatureConstants._
+import com.johnsnowlabs.ml.util.Openvino
+import com.johnsnowlabs.util.{FileHelper, ZipArchiveUtil}
+import org.apache.commons.io.FileUtils
+import org.intel.openvino.{CompiledModel, Core, Model}
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+import java.util.UUID
+import scala.collection.JavaConverters._
+
+class OpenvinoWrapper(modelBytes: Array[Byte], weightsBytes: Array[Array[Byte]])
+    extends Serializable {
+
+  /** For Deserialization */
+  def this() = {
+    this(null, null)
+  }
+
+  // Important for serialization on none-kyro serializers
+  @transient private val logger = LoggerFactory.getLogger(this.getClass.toString)
+  @transient private var compiledModel: CompiledModel = _
+
+  def getCompiledModel(
+      device: String = "AUTO",
+      properties: Map[String, String] = Map.empty): CompiledModel =
+    this.synchronized {
+      if (compiledModel == null) {
+        val path = Files
+          .createTempDirectory(
+            UUID.randomUUID().toString.takeRight(12) + OpenvinoWrapper.ModelSuffix)
+          .toAbsolutePath
+          .toString
+        val tmpModelPath = Paths.get(path, Openvino.modelXml)
+        val tmpWeightsPath = Paths.get(path, Openvino.modelBin)
+
+        // save the binary data of the model and weights to files
+        FileUtils.writeByteArrayToFile(tmpModelPath.toFile, modelBytes)
+        ChunkBytes.writeByteChunksInFile(tmpWeightsPath, weightsBytes)
+
+        compiledModel = OpenvinoWrapper.core.compile_model(
+          tmpModelPath.toAbsolutePath.toString,
+          device,
+          properties.asJava)
+
+        logger.debug(
+          s"Compiled OpenVINO IR model on device: $device with properties: $properties")
+        FileHelper.delete(path)
+      }
+      compiledModel
+    }
+
+  def saveToFile(file: String): Unit = {
+    val tmpFolder = Files
+      .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_ov")
+      .toAbsolutePath
+      .toString
+
+    FileUtils.writeByteArrayToFile(Paths.get(tmpFolder, Openvino.modelXml).toFile, modelBytes)
+    ChunkBytes.writeByteChunksInFile(Paths.get(tmpFolder, Openvino.modelBin), weightsBytes)
+
+    ZipArchiveUtil.zip(tmpFolder, file)
+    FileHelper.delete(tmpFolder)
+  }
+
+}
+
+/** Companion object */
+object OpenvinoWrapper {
+
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass.toString)
+  private[OpenvinoWrapper] val core: Core = this.synchronized {
+    if (core == null) {
+      new Core()
+    } else {
+      core
+    }
+  }
+
+  // size of bytes store in each chunk/array
+  private val BUFFER_SIZE = 1024 * 1024
+
+  private val ModelSuffix = "_ov_model"
+
+  /** Reads models from supported file formats and exports them into OpenVINO Intermediate
+    * Representation (IR) format. The resulting framework-independent model representation
+    * consists of a model graph (.xml) and weights (.bin) files.
+    *
+    * @param modelPath
+    *   Path to the source model
+    * @param targetPath
+    *   Path to the converted model directory
+    * @param useBundle
+    *   Read from a provided model bundle
+    * @param zipped
+    *   Unpack the zipped model
+    */
+  def convertToOpenvinoFormat(
+      modelPath: String,
+      targetPath: String,
+      useBundle: Boolean,
+      zipped: Boolean = true): Unit = {
+    val tmpFolder = Files
+      .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + ModelSuffix)
+      .toAbsolutePath
+      .toString
+
+    val folder =
+      if (zipped) {
+        ZipArchiveUtil.unzip(new File(modelPath), Some(tmpFolder))
+      } else {
+        modelPath
+      }
+
+    // TODO verify logic for useBundle
+    val actualPath =
+      if (useBundle) {
+        folder
+      } else {
+        Paths.get(folder, TensorflowWrapper.SavedModelPB).toAbsolutePath.toString
+      }
+
+    logger.debug(
+      s"Attempting to convert the saved model to OpenVINO Intermediate format, useBundle: $useBundle...")
+    val model: Model = core.read_model(actualPath)
+    val ovModelPath = Paths.get(targetPath, Openvino.modelXml).toAbsolutePath.toString
+    val ovWeightsPath = Paths.get(targetPath, Openvino.modelBin).toAbsolutePath.toString
+    org.intel.openvino.Openvino.serialize(model, ovModelPath, ovWeightsPath)
+
+    FileHelper.delete(tmpFolder)
+  }
+
+  /** Reads a model saved in the OpenVINO IR format and loads the OpenVINO model wrapper.
+    *
+    * @param path
+    *   Path to the IR model folder
+    * @param zipped
+    *   Unpack zipped model
+    * @param device
+    *   Device to load model on
+    * @param properties
+    *   Properties for this load operation
+    * @return
+    *   The OpenVINO model wrapper and the normalized tensor name map for the model
+    */
+  def fromOpenvinoFormat(
+      path: String,
+      zipped: Boolean = true,
+      device: String = "AUTO",
+      properties: Map[String, String] = Map.empty): (OpenvinoWrapper, Map[String, String]) = {
+
+    val tmpFolder = Files
+      .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + ModelSuffix)
+      .toAbsolutePath
+      .toString
+
+    val folder =
+      if (zipped)
+        ZipArchiveUtil.unzip(new File(path), Some(tmpFolder))
+      else
+        path
+
+    val modelPath = Paths.get(folder, Openvino.modelXml)
+    val weightsPath = Paths.get(folder, Openvino.modelBin)
+
+    logger.debug(s"Reading and compiling IR model on device: $device...")
+    val modelBytes = FileUtils.readFileToByteArray(modelPath.toFile)
+    val weightsBytes = ChunkBytes.readFileInByteChunks(weightsPath, BUFFER_SIZE)
+    val compiledModel: CompiledModel =
+      core.compile_model(modelPath.toAbsolutePath.toString, device, properties.asJava)
+
+    val openvinoWrapper = new OpenvinoWrapper(modelBytes, weightsBytes)
+    openvinoWrapper.compiledModel = compiledModel
+
+    val tensorNamesMap = (compiledModel.outputs().asScala ++ compiledModel.inputs().asScala)
+      .map(_.get_any_name())
+      .map(tensorName => {
+        tensorName match {
+          case "input_ids" | "input_word_ids" => InputIds.key -> tensorName
+          case "input_mask" | "attention_mask" => AttentionMask.key -> tensorName
+          case "segment_ids" | "input_type_ids" | "token_type_ids" =>
+            TokenTypeIds.key -> tensorName
+          case "sequence_output" | "bert_encoder" | "last_hidden_state" =>
+            LastHiddenState.key -> tensorName
+          case "pooler_output" => PoolerOutput.key -> tensorName
+          case k => k -> k
+        }
+      })
+      .toMap
+
+    FileHelper.delete(tmpFolder)
+    (openvinoWrapper, tensorNamesMap)
+  }
+}

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -118,15 +118,14 @@ object OpenvinoWrapper {
         modelPath
       }
 
-    logger.debug(
-      s"Converting the $detectedEngine model to OpenVINO Intermediate format")
+    logger.debug(s"Converting the $detectedEngine model to OpenVINO Intermediate format")
 
     val srcModelPath: String =
       detectedEngine match {
         case TensorFlow.name =>
           folder
         case ONNX.name =>
-          folder + ONNX.modelName
+          Paths.get(folder, ONNX.modelName).toString
       }
 
     val model: Model = core.read_model(srcModelPath)

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.ml.openvino
 
 import com.johnsnowlabs.ml.tensorflow.io.ChunkBytes
-import com.johnsnowlabs.ml.tensorflow.sign.ModelSignatureConstants._
-import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.ml.tensorflow.sign.ModelSignatureConstants
 import com.johnsnowlabs.ml.util.{ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.util.{FileHelper, ZipArchiveUtil}
 import org.apache.commons.io.FileUtils
@@ -74,13 +89,7 @@ class OpenvinoWrapper(modelBytes: Array[Byte], weightsBytes: Array[Array[Byte]])
 object OpenvinoWrapper {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass.toString)
-  private[OpenvinoWrapper] val core: Core = this.synchronized {
-    if (core == null) {
-      new Core()
-    } else {
-      core
-    }
-  }
+  private[OpenvinoWrapper] val core: Core = new Core
 
   // size of bytes store in each chunk/array
   private val BUFFER_SIZE = 1024 * 1024
@@ -88,8 +97,8 @@ object OpenvinoWrapper {
   private val ModelSuffix = "_ov_model"
 
   /** Reads models from supported file formats and exports them into OpenVINO Intermediate
-    * Representation (IR) format. The resulting framework-independent model representation
-    * consists of a model graph (.xml) and weights (.bin) files.
+    * Representation (IR) format. The resulting model representation consists of a model graph
+    * (.xml) and weights (.bin) files.
     *
     * @param modelPath
     *   Path to the source model
@@ -104,7 +113,6 @@ object OpenvinoWrapper {
       modelPath: String,
       targetPath: String,
       detectedEngine: String,
-      useBundle: Boolean,
       zipped: Boolean = true): Unit = {
     val tmpFolder = Files
       .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + ModelSuffix)
@@ -126,6 +134,8 @@ object OpenvinoWrapper {
           folder
         case ONNX.name =>
           Paths.get(folder, ONNX.modelName).toString
+        case _ =>
+          throw new Exception(s"Unsupported model framework ${detectedEngine}!")
       }
 
     val model: Model = core.read_model(srcModelPath)

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -3,7 +3,7 @@ package com.johnsnowlabs.ml.openvino
 import com.johnsnowlabs.ml.tensorflow.TensorflowWrapper
 import com.johnsnowlabs.ml.tensorflow.io.ChunkBytes
 import com.johnsnowlabs.ml.tensorflow.sign.ModelSignatureConstants._
-import com.johnsnowlabs.ml.util.Openvino
+import com.johnsnowlabs.ml.util.{ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.util.{FileHelper, ZipArchiveUtil}
 import org.apache.commons.io.FileUtils
 import org.intel.openvino.{CompiledModel, Core, Model}
@@ -103,6 +103,7 @@ object OpenvinoWrapper {
   def convertToOpenvinoFormat(
       modelPath: String,
       targetPath: String,
+      detectedEngine: String,
       useBundle: Boolean,
       zipped: Boolean = true): Unit = {
     val tmpFolder = Files
@@ -117,17 +118,18 @@ object OpenvinoWrapper {
         modelPath
       }
 
-    // TODO verify logic for useBundle
-    val actualPath =
-      if (useBundle) {
-        folder
-      } else {
-        Paths.get(folder, TensorflowWrapper.SavedModelPB).toAbsolutePath.toString
+    logger.debug(
+      s"Attempting to convert the $detectedEngine model to OpenVINO Intermediate format")
+
+    val srcModelPath: String =
+      detectedEngine match {
+        case TensorFlow.name =>
+          modelPath
+        case ONNX.name =>
+          modelPath + "/model.onnx"
       }
 
-    logger.debug(
-      s"Attempting to convert the saved model to OpenVINO Intermediate format, useBundle: $useBundle...")
-    val model: Model = core.read_model(actualPath)
+    val model: Model = core.read_model(srcModelPath)
     val ovModelPath = Paths.get(targetPath, Openvino.modelXml).toAbsolutePath.toString
     val ovWeightsPath = Paths.get(targetPath, Openvino.modelBin).toAbsolutePath.toString
     org.intel.openvino.Openvino.serialize(model, ovModelPath, ovWeightsPath)

--- a/src/main/scala/com/johnsnowlabs/ml/util/ModelEngine.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/ModelEngine.scala
@@ -33,6 +33,11 @@ final case object ONNX extends ModelEngine {
   val decoderModel = "decoder_model.onnx"
   val decoderWithPastModel = "decoder_with_past_model.onnx"
 }
+final case object Openvino extends ModelEngine {
+  val name = "openvino"
+  val modelXml = "saved_model.xml"
+  val modelBin = "saved_model.bin"
+}
 
 final case object Unknown extends ModelEngine {
   val name = "unk"

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -496,6 +496,7 @@ trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel with ReadOp
             OpenvinoWrapper.convertToOpenvinoFormat(
               modelPath = localModelPath,
               targetPath = tmpFolder,
+              detectedEngine = detectedEngine,
               zipped = false,
               useBundle = true)
             tmpFolder

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -497,8 +497,7 @@ trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel with ReadOp
               modelPath = localModelPath,
               targetPath = tmpFolder,
               detectedEngine = detectedEngine,
-              zipped = false,
-              useBundle = true)
+              zipped = false)
             tmpFolder
           }
         val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -18,23 +18,28 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.Bert
 import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
+import com.johnsnowlabs.ml.openvino.{OpenvinoWrapper, ReadOpenvinoModel, WriteOpenvinoModel}
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.util.LoadExternalModel.{
   loadTextAsset,
   modelSanityCheck,
   notSupportedEngineError
 }
-import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.storage.HasStorageRef
+import com.johnsnowlabs.util.FileHelper
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{IntArrayParam, IntParam}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.{Logger, LoggerFactory}
+
+import java.nio.file.Files
+import java.util.UUID
 
 /** Token-level embeddings using BERT. BERT (Bidirectional Encoder Representations from
   * Transformers) provides dense vector representations for natural language by using a deep,
@@ -159,6 +164,7 @@ class BertEmbeddings(override val uid: String)
     with HasBatchedAnnotate[BertEmbeddings]
     with WriteTensorflowModel
     with WriteOnnxModel
+    with WriteOpenvinoModel
     with HasEmbeddingsProperties
     with HasStorageRef
     with HasCaseSensitiveProperties
@@ -260,13 +266,15 @@ class BertEmbeddings(override val uid: String)
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: Option[TensorflowWrapper],
-      onnxWrapper: Option[OnnxWrapper]): BertEmbeddings = {
+      onnxWrapper: Option[OnnxWrapper],
+      openvinoWrapper: Option[OpenvinoWrapper]): BertEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
           new Bert(
             tensorflowWrapper,
             onnxWrapper,
+            openvinoWrapper,
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
@@ -393,7 +401,13 @@ class BertEmbeddings(override val uid: String)
           getModelIfNotSet.onnxWrapper.get,
           suffix,
           BertEmbeddings.onnxFile)
-
+      case Openvino.name =>
+        writeOpenvinoModel(
+          path,
+          spark,
+          getModelIfNotSet.openvinoWrapper.get,
+          suffix,
+          BertEmbeddings.openvinoFile)
       case _ =>
         throw new Exception(notSupportedEngineError)
     }
@@ -418,24 +432,29 @@ trait ReadablePretrainedBertModel
     super.pretrained(name, lang, remoteLoc)
 }
 
-trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel {
+trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel with ReadOpenvinoModel {
   this: ParamsAndFeaturesReadable[BertEmbeddings] =>
 
   override val tfFile: String = "bert_tensorflow"
   override val onnxFile: String = "bert_onnx"
+  override val openvinoFile: String = "bert_openvino"
 
   def readModel(instance: BertEmbeddings, path: String, spark: SparkSession): Unit = {
 
     instance.getEngine match {
       case TensorFlow.name =>
         val tfWrapper = readTensorflowModel(path, spark, "_bert_tf", initAllTables = false)
-        instance.setModelIfNotSet(spark, Some(tfWrapper), None)
+        instance.setModelIfNotSet(spark, Some(tfWrapper), None, None)
 
       case ONNX.name => {
         val onnxWrapper =
           readOnnxModel(path, spark, "_bert_onnx", zipped = true, useBundle = false, None)
-        instance.setModelIfNotSet(spark, None, Some(onnxWrapper))
+        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), None)
       }
+
+      case Openvino.name =>
+        val openvinoWrapper = readOpenvinoModel(path, spark, "_bert_openvino")
+        instance.setModelIfNotSet(spark, None, None, Some(openvinoWrapper))
       case _ =>
         throw new Exception(notSupportedEngineError)
     }
@@ -443,7 +462,10 @@ trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel {
 
   addReader(readModel)
 
-  def loadSavedModel(modelPath: String, spark: SparkSession): BertEmbeddings = {
+  def loadSavedModel(
+      modelPath: String,
+      spark: SparkSession,
+      useOpenvino: Boolean = false): BertEmbeddings = {
 
     val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
 
@@ -452,10 +474,43 @@ trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel {
     /*Universal parameters for all engines*/
     val annotatorModel = new BertEmbeddings()
       .setVocabulary(vocabs)
+    val modelEngine =
+      if (useOpenvino)
+        Openvino.name
+      else
+        detectedEngine
+    annotatorModel.set(annotatorModel.engine, modelEngine)
 
-    annotatorModel.set(annotatorModel.engine, detectedEngine)
+    modelEngine match {
+      case Openvino.name =>
+        val tmpFolder = Files
+          .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_ov_model")
+          .toAbsolutePath
+          .toString
 
-    detectedEngine match {
+        /** Convert the model from the detected framework to Openvino Intermediate format */
+        val irModelFolder =
+          if (detectedEngine == Openvino.name) {
+            localModelPath
+          } else {
+            OpenvinoWrapper.convertToOpenvinoFormat(
+              modelPath = localModelPath,
+              targetPath = tmpFolder,
+              zipped = false,
+              useBundle = true)
+            tmpFolder
+          }
+        val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =
+          OpenvinoWrapper.fromOpenvinoFormat(irModelFolder, zipped = false)
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel.setSignatures(tensorNames)
+        annotatorModel
+          .setModelIfNotSet(spark, None, None, Some(ovWrapper))
+        FileHelper.delete(tmpFolder)
+
       case TensorFlow.name =>
         val (tfWrapper, signatures) =
           TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
@@ -470,12 +525,12 @@ trait ReadBertDLModel extends ReadTensorflowModel with ReadOnnxModel {
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, Some(tfWrapper), None)
+          .setModelIfNotSet(spark, Some(tfWrapper), None, None)
 
       case ONNX.name =>
         val onnxWrapper = OnnxWrapper.read(localModelPath, zipped = false, useBundle = true)
         annotatorModel
-          .setModelIfNotSet(spark, None, Some(onnxWrapper))
+          .setModelIfNotSet(spark, None, Some(onnxWrapper), None)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
@@ -315,6 +315,7 @@ class BertSentenceEmbeddings(override val uid: String)
           new Bert(
             tensorflowWrapper,
             onnxWrapper,
+            None,
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/LongformerEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/LongformerEmbeddings.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.RoBerta
 import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
+import com.johnsnowlabs.ml.openvino.OpenvinoWrapper
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.util.LoadExternalModel.{
   loadTextAsset,
@@ -249,13 +250,15 @@ class LongformerEmbeddings(override val uid: String)
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: Option[TensorflowWrapper],
-      onnxWrapper: Option[OnnxWrapper]): LongformerEmbeddings = {
+      onnxWrapper: Option[OnnxWrapper],
+      openvinoWrapper: Option[OpenvinoWrapper]): LongformerEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
           new RoBerta(
             tensorflowWrapper,
             onnxWrapper,
+            openvinoWrapper,
             sentenceStartTokenId,
             sentenceEndTokenId,
             padTokenId,
@@ -417,7 +420,7 @@ trait ReadLongformerDLModel extends ReadTensorflowModel {
   def readModel(instance: LongformerEmbeddings, path: String, spark: SparkSession): Unit = {
 
     val tf = readTensorflowModel(path, spark, "_longformer_tf", initAllTables = false)
-    instance.setModelIfNotSet(spark, Some(tf), None)
+    instance.setModelIfNotSet(spark, Some(tf), None, None)
   }
 
   addReader(readModel)
@@ -457,7 +460,7 @@ trait ReadLongformerDLModel extends ReadTensorflowModel {
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, Some(wrapper), None)
+          .setModelIfNotSet(spark, Some(wrapper), None, None)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
@@ -18,22 +18,27 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.RoBerta
 import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
+import com.johnsnowlabs.ml.openvino.{OpenvinoWrapper, ReadOpenvinoModel, WriteOpenvinoModel}
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.util.LoadExternalModel.{
   loadTextAsset,
   modelSanityCheck,
   notSupportedEngineError
 }
-import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.annotators.tokenizer.bpe.BpeTokenizer
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.storage.HasStorageRef
+import com.johnsnowlabs.util.FileHelper
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{IntArrayParam, IntParam}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.nio.file.Files
+import java.util.UUID
 
 /** The RoBERTa model was proposed in
   * [[https://arxiv.org/abs/1907.11692 RoBERTa: A Robustly Optimized BERT Pretraining Approach]]
@@ -164,6 +169,7 @@ class RoBertaEmbeddings(override val uid: String)
     with HasBatchedAnnotate[RoBertaEmbeddings]
     with WriteTensorflowModel
     with WriteOnnxModel
+    with WriteOpenvinoModel
     with HasEmbeddingsProperties
     with HasStorageRef
     with HasCaseSensitiveProperties
@@ -263,13 +269,15 @@ class RoBertaEmbeddings(override val uid: String)
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: Option[TensorflowWrapper],
-      onnxWrapper: Option[OnnxWrapper]): RoBertaEmbeddings = {
+      onnxWrapper: Option[OnnxWrapper],
+      openvinoWrapper: Option[OpenvinoWrapper]): RoBertaEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
           new RoBerta(
             tensorflowWrapper,
             onnxWrapper,
+            openvinoWrapper,
             sentenceStartTokenId,
             sentenceEndTokenId,
             padTokenId,
@@ -413,6 +421,13 @@ class RoBertaEmbeddings(override val uid: String)
           getModelIfNotSet.onnxWrapper.get,
           suffix,
           RoBertaEmbeddings.onnxFile)
+      case Openvino.name =>
+        writeOpenvinoModel(
+          path,
+          spark,
+          getModelIfNotSet.openvinoWrapper.get,
+          suffix,
+          RoBertaEmbeddings.openvinoFile)
 
       case _ =>
         throw new Exception(notSupportedEngineError)
@@ -437,23 +452,30 @@ trait ReadablePretrainedRobertaModel
     super.pretrained(name, lang, remoteLoc)
 }
 
-trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel {
+trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel with ReadOpenvinoModel {
   this: ParamsAndFeaturesReadable[RoBertaEmbeddings] =>
 
   override val tfFile: String = "roberta_tensorflow"
   override val onnxFile: String = "roberta_onnx"
+  override val openvinoFile: String = "roberta_openvino"
 
   def readModel(instance: RoBertaEmbeddings, path: String, spark: SparkSession): Unit = {
 
     instance.getEngine match {
       case TensorFlow.name =>
         val tfWrapper = readTensorflowModel(path, spark, "_roberta_tf", initAllTables = false)
-        instance.setModelIfNotSet(spark, Some(tfWrapper), None)
+        instance.setModelIfNotSet(spark, Some(tfWrapper), None, None)
 
       case ONNX.name => {
         val onnxWrapper =
           readOnnxModel(path, spark, "_roberta_onnx", zipped = true, useBundle = false, None)
-        instance.setModelIfNotSet(spark, None, Some(onnxWrapper))
+        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), None)
+      }
+
+      case Openvino.name => {
+        val openvinoWrapper =
+          readOpenvinoModel(path, spark, "_roberta_openvino")
+        instance.setModelIfNotSet(spark, None, None, Some(openvinoWrapper))
       }
       case _ =>
         throw new Exception(notSupportedEngineError)
@@ -462,7 +484,10 @@ trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel {
 
   addReader(readModel)
 
-  def loadSavedModel(modelPath: String, spark: SparkSession): RoBertaEmbeddings = {
+  def loadSavedModel(
+      modelPath: String,
+      spark: SparkSession,
+      useOpenvino: Boolean): RoBertaEmbeddings = {
 
     val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
 
@@ -480,9 +505,14 @@ trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel {
       .setVocabulary(vocabs)
       .setMerges(bytePairs)
 
-    annotatorModel.set(annotatorModel.engine, detectedEngine)
+    val modelEngine =
+      if (useOpenvino)
+        Openvino.name
+      else
+        detectedEngine
+    annotatorModel.set(annotatorModel.engine, modelEngine)
 
-    detectedEngine match {
+    modelEngine match {
       case TensorFlow.name =>
         val (wrapper, signatures) =
           TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
@@ -497,12 +527,41 @@ trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel {
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, Some(wrapper), None)
+          .setModelIfNotSet(spark, Some(wrapper), None, None)
 
       case ONNX.name =>
         val onnxWrapper = OnnxWrapper.read(localModelPath, zipped = false, useBundle = true)
         annotatorModel
-          .setModelIfNotSet(spark, None, Some(onnxWrapper))
+          .setModelIfNotSet(spark, None, Some(onnxWrapper), None)
+
+      case Openvino.name =>
+        val tmpFolder = Files
+          .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_ov_model")
+          .toAbsolutePath
+          .toString
+
+        /** Convert the model from the detected framework to Openvino Intermediate format */
+        val irModelFolder =
+          if (detectedEngine == Openvino.name) {
+            localModelPath
+          } else {
+            OpenvinoWrapper.convertToOpenvinoFormat(
+              modelPath = localModelPath,
+              targetPath = tmpFolder,
+              zipped = false,
+              useBundle = true)
+            tmpFolder
+          }
+        val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =
+          OpenvinoWrapper.fromOpenvinoFormat(irModelFolder, zipped = false)
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel.setSignatures(tensorNames)
+        annotatorModel
+          .setModelIfNotSet(spark, None, None, Some(ovWrapper))
+        FileHelper.delete(tmpFolder)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
@@ -548,6 +548,7 @@ trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel with Rea
             OpenvinoWrapper.convertToOpenvinoFormat(
               modelPath = localModelPath,
               targetPath = tmpFolder,
+              detectedEngine = detectedEngine,
               zipped = false,
               useBundle = true)
             tmpFolder

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
@@ -549,8 +549,7 @@ trait ReadRobertaDLModel extends ReadTensorflowModel with ReadOnnxModel with Rea
               modelPath = localModelPath,
               targetPath = tmpFolder,
               detectedEngine = detectedEngine,
-              zipped = false,
-              useBundle = true)
+              zipped = false)
             tmpFolder
           }
         val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.RoBerta
 import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
+import com.johnsnowlabs.ml.openvino.OpenvinoWrapper
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.util.LoadExternalModel.{
   loadTextAsset,
@@ -259,13 +260,15 @@ class RoBertaSentenceEmbeddings(override val uid: String)
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: Option[TensorflowWrapper],
-      onnxWrapper: Option[OnnxWrapper]): RoBertaSentenceEmbeddings = {
+      onnxWrapper: Option[OnnxWrapper],
+      openvinoWrapper: Option[OpenvinoWrapper]): RoBertaSentenceEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
           new RoBerta(
             tensorflowWrapper,
             onnxWrapper,
+            openvinoWrapper,
             sentenceStartTokenId,
             sentenceEndTokenId,
             padTokenId,
@@ -406,7 +409,7 @@ trait ReadRobertaSentenceDLModel extends ReadTensorflowModel {
   def readModel(instance: RoBertaSentenceEmbeddings, path: String, spark: SparkSession): Unit = {
 
     val tf = readTensorflowModel(path, spark, "_roberta_tf", initAllTables = false)
-    instance.setModelIfNotSet(spark, Some(tf), None)
+    instance.setModelIfNotSet(spark, Some(tf), None, None)
   }
 
   addReader(readModel)
@@ -446,7 +449,7 @@ trait ReadRobertaSentenceDLModel extends ReadTensorflowModel {
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, Some(wrapper), None)
+          .setModelIfNotSet(spark, Some(wrapper), None, None)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -498,8 +498,7 @@ trait ReadXlmRobertaDLModel
               modelPath = localModelPath,
               targetPath = tmpFolder,
               detectedEngine = detectedEngine,
-              zipped = false,
-              useBundle = true)
+              zipped = false)
             tmpFolder
           }
         val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -497,6 +497,7 @@ trait ReadXlmRobertaDLModel
             OpenvinoWrapper.convertToOpenvinoFormat(
               modelPath = localModelPath,
               targetPath = tmpFolder,
+              detectedEngine = detectedEngine,
               zipped = false,
               useBundle = true)
             tmpFolder

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.XlmRoberta
 import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
+import com.johnsnowlabs.ml.openvino.{OpenvinoWrapper, ReadOpenvinoModel, WriteOpenvinoModel}
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
   ReadSentencePieceModel,
@@ -29,15 +30,19 @@ import com.johnsnowlabs.ml.util.LoadExternalModel.{
   modelSanityCheck,
   notSupportedEngineError
 }
-import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, Openvino, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.storage.HasStorageRef
+import com.johnsnowlabs.util.FileHelper
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{IntArrayParam, IntParam}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.nio.file.Files
+import java.util.UUID
 
 /** The XLM-RoBERTa model was proposed in
   * [[https://arxiv.org/abs/1911.02116 Unsupervised Cross-lingual Representation Learning at Scale]]
@@ -169,6 +174,7 @@ class XlmRoBertaEmbeddings(override val uid: String)
     with WriteTensorflowModel
     with WriteSentencePieceModel
     with WriteOnnxModel
+    with WriteOpenvinoModel
     with HasEmbeddingsProperties
     with HasStorageRef
     with HasCaseSensitiveProperties
@@ -239,6 +245,7 @@ class XlmRoBertaEmbeddings(override val uid: String)
       spark: SparkSession,
       tensorflowWrapper: Option[TensorflowWrapper],
       onnxWrapper: Option[OnnxWrapper],
+      openvinoWrapper: Option[OpenvinoWrapper],
       spp: SentencePieceWrapper): XlmRoBertaEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
@@ -246,6 +253,7 @@ class XlmRoBertaEmbeddings(override val uid: String)
           new XlmRoberta(
             tensorflowWrapper,
             onnxWrapper,
+            openvinoWrapper,
             spp,
             $(caseSensitive),
             configProtoBytes = getConfigProtoBytes,
@@ -354,6 +362,13 @@ class XlmRoBertaEmbeddings(override val uid: String)
           getModelIfNotSet.onnxWrapper.get,
           suffix,
           XlmRoBertaEmbeddings.onnxFile)
+      case Openvino.name =>
+        writeOpenvinoModel(
+          path,
+          spark,
+          getModelIfNotSet.openvinoWrapper.get,
+          suffix,
+          XlmRoBertaEmbeddings.openvinoFile)
 
       case _ =>
         throw new Exception(notSupportedEngineError)
@@ -390,11 +405,13 @@ trait ReadablePretrainedXlmRobertaModel
 trait ReadXlmRobertaDLModel
     extends ReadTensorflowModel
     with ReadSentencePieceModel
-    with ReadOnnxModel {
+    with ReadOnnxModel
+    with ReadOpenvinoModel {
   this: ParamsAndFeaturesReadable[XlmRoBertaEmbeddings] =>
 
   override val tfFile: String = "xlmroberta_tensorflow"
   override val onnxFile: String = "xlmroberta_onnx"
+  override val openvinoFile: String = "xlmroberta_openvino"
   override val sppFile: String = "xlmroberta_spp"
 
   def readModel(instance: XlmRoBertaEmbeddings, path: String, spark: SparkSession): Unit = {
@@ -403,13 +420,20 @@ trait ReadXlmRobertaDLModel
       case TensorFlow.name =>
         val tfWrapper = readTensorflowModel(path, spark, "_xlmroberta_tf", initAllTables = false)
         val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
-        instance.setModelIfNotSet(spark, Some(tfWrapper), None, spp)
+        instance.setModelIfNotSet(spark, Some(tfWrapper), None, None, spp)
 
       case ONNX.name => {
         val onnxWrapper =
           readOnnxModel(path, spark, "_xlmroberta_onnx", zipped = true, useBundle = false, None)
         val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
-        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), spp)
+        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), None, spp)
+      }
+
+      case Openvino.name => {
+        val openvinoWrapper =
+          readOpenvinoModel(path, spark, "_xlmroberta_openvino")
+        val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
+        instance.setModelIfNotSet(spark, None, None, Some(openvinoWrapper), spp)
       }
       case _ =>
         throw new Exception(notSupportedEngineError)
@@ -418,7 +442,10 @@ trait ReadXlmRobertaDLModel
 
   addReader(readModel)
 
-  def loadSavedModel(modelPath: String, spark: SparkSession): XlmRoBertaEmbeddings = {
+  def loadSavedModel(
+      modelPath: String,
+      spark: SparkSession,
+      useOpenvino: Boolean = false): XlmRoBertaEmbeddings = {
 
     val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
 
@@ -426,10 +453,15 @@ trait ReadXlmRobertaDLModel
 
     /*Universal parameters for all engines*/
     val annotatorModel = new XlmRoBertaEmbeddings()
+    val modelEngine =
+      if (useOpenvino)
+        Openvino.name
+      else
+        detectedEngine
 
-    annotatorModel.set(annotatorModel.engine, detectedEngine)
+    annotatorModel.set(annotatorModel.engine, modelEngine)
 
-    detectedEngine match {
+    modelEngine match {
       case TensorFlow.name =>
         val (tfWrapper, signatures) =
           TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
@@ -444,12 +476,41 @@ trait ReadXlmRobertaDLModel
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, Some(tfWrapper), None, spModel)
+          .setModelIfNotSet(spark, Some(tfWrapper), None, None, spModel)
 
       case ONNX.name =>
         val onnxWrapper = OnnxWrapper.read(localModelPath, zipped = false, useBundle = true)
         annotatorModel
-          .setModelIfNotSet(spark, None, Some(onnxWrapper), spModel)
+          .setModelIfNotSet(spark, None, Some(onnxWrapper), None, spModel)
+
+      case Openvino.name =>
+        val tmpFolder = Files
+          .createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_ov_model")
+          .toAbsolutePath
+          .toString
+
+        /** Convert the model from the detected framework to Openvino Intermediate format */
+        val irModelFolder =
+          if (detectedEngine == Openvino.name) {
+            localModelPath
+          } else {
+            OpenvinoWrapper.convertToOpenvinoFormat(
+              modelPath = localModelPath,
+              targetPath = tmpFolder,
+              zipped = false,
+              useBundle = true)
+            tmpFolder
+          }
+        val (ovWrapper: OpenvinoWrapper, tensorNames: Map[String, String]) =
+          OpenvinoWrapper.fromOpenvinoFormat(irModelFolder, zipped = false)
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel.setSignatures(tensorNames)
+        annotatorModel
+          .setModelIfNotSet(spark, None, None, Some(ovWrapper), spModel)
+        FileHelper.delete(tmpFolder)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
@@ -242,6 +242,7 @@ class XlmRoBertaSentenceEmbeddings(override val uid: String)
           new XlmRoberta(
             tensorflowWrapper,
             onnxWrapper,
+            None,
             spp,
             $(caseSensitive),
             configProtoBytes = getConfigProtoBytes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for using the OpenVINO Runtime API to load and infer models built and trained using [supported](https://docs.openvino.ai/2023.0/Supported_Model_Formats.html)
frameworks with no additional ML library dependencies. The following annotators are supported so far

- [x] BertEmbeddings


## Motivation and Context

- Out-of-the-box optimizations and better performance on supported Intel hardware
- Extends support for loading ONNX, PaddlePaddle, TensorFlow and TensorFlow Lite models

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
